### PR TITLE
ontop-mysql: Unzip MySQL compressed scripts

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,9 +1,12 @@
 FROM mysql:5.7.17
 
-RUN apt-get  update && apt-get install -y wget unzip
+RUN apt-get  update && apt-get install -y wget unzip gzip
 
 # copying all SQL files to this folder will automatically put them in the default DB
 COPY sql/*.sql.gz /docker-entrypoint-initdb.d/
+
+# unzip all compressed files to ensure they are run
+RUN cd /docker-entrypoint-initdb.d && gunzip *.gz
 
 #get fish database dump file , unzip it and load
 RUN wget -P /tmp/sql_scripts/ -o log  http://obdavm.inf.unibz.it/dumps/fbapp.sql.zip && \


### PR DESCRIPTION
MySQL scripts previously compressed (https://github.com/ontop/ontop-dockertests/commit/ffaff0e8507f28477c1cfe460cbdc84ec63516df) and whose SQL scripts were deleted (https://github.com/ontop/ontop-dockertests/commit/eed05073e3ce81587b0826e0c758e5c6867ed36e) were not being unzipped once the docker image was launched. None of these scripts were therefore run. Change necessary in order to build correctly (if a user does not want to use the dockerhub image) the mysql docker image for the Ontop tests.